### PR TITLE
Add GH pages automation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    branches: [ main ]
+
+name: Deploy to GitHub pages
+
+jobs:
+
+  gh-pages:
+
+    name: Deploy to GH pages
+    runs-on: ubuntu-latest
+    env:
+      node-vesion: 15.x
+      cname: demo.objectcut.com
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Use Node.js ${{ env.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ env.node-version }}
+
+    - name: Create temporary NPM cache
+      run: npm install --cache /tmp/empty-cache
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run-script build
+
+    - name: Create CNAME
+      run: echo '${{ env.cname }}' > dist/CNAME
+    
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@3.6.2
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: dist

--- a/README.md
+++ b/README.md
@@ -1,24 +1,52 @@
-# bg-removal-web
+# Object Cut demo
+
+[![HitCount](http://hits.dwyl.io/Rahuvich/objectcut-website.svg)](http://hits.dwyl.io/Rahuvich/objectcut-website)
+![Deploy to GitHub pages](https://github.com/Rahuvich/objectcut-website/workflows/Deploy%20to%20GitHub%20pages/badge.svg)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/Rahuvich/objectcut-website)
+[![GitHub stars](https://img.shields.io/github/stars/Rahuvich/objectcut-website.svg)](https://GitHub.com/Rahuvich/objectcut-website/stargazers/)
+[![GitHub forks](https://img.shields.io/github/forks/Rahuvich/objectcut-website.svg)](https://GitHub.com/Rahuvich/objectcut-website/network/)
+[![GitHub repo size in bytes](https://img.shields.io/github/repo-size/Rahuvich/objectcut-website.svg)](https://github.com/Rahuvich/objectcut-website)
+
+[Demo](https://demo.objectcut.com/) | [Website](https://objectcut.com/) | [RapidAPI](https://rapidapi.com/objectcut.api/api/background-removal) | [API Repository](https://github.com/AlbertSuarez/object-cut)
+
+✂️ Demo page of the Object Cut API
+
+## Requirements
+
+1. Vue 2.6.11+
 
 ## Project setup
+
 ```
 yarn install
 ```
 
 ### Compiles and hot-reloads for development
+
 ```
 yarn serve
 ```
 
 ### Compiles and minifies for production
+
 ```
 yarn build
 ```
 
 ### Lints and fixes files
+
 ```
 yarn lint
 ```
 
 ### Customize configuration
+
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+## Authors
+
+- [Raul Mateo Beneyto](https://github.com/Rahuvich)
+
+## License
+
+Apache-2.0 © ObjectCut


### PR DESCRIPTION
Hey Raul!

This PR includes a GitHub Actions workflow for building the Vue application and pushing the compiled code to the `gh-pages` branch.

If you agreed on the changes and you want to move forward, these are the things that you should do for deploying your beautiful demo under `demo.objectcut.com`.

1. Merge this PR and wait for the GitHub action to be completed (you can check it [here](https://github.com/AlbertSuarez/objectcut-website/actions)). This process will be done after every push to `main`.
2. Once done, you will have a new `gh-pages` branch with the compiled code.
3. Go the `Settings` > `Options` > `GitHub Pages` and select the `Source` with the `gh-pages` branch, and then `Save`.
4. Once done, please be sure that the `Enforce HTTPS` is enabled (you might wait some minutes for GitHub to validate the domain).

At this point, your website should be published under `demo.objectcut.com` 🤚 